### PR TITLE
feat : INFO 레벨 로그와 ERRROR레벨 로그를 파일로 저장.

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -9,18 +9,66 @@
     <!-- 변수명과, 패턴 저장 -->
     <property name="CONSOLE_LOG_PATTERN"
               value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger) - %msg%n"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
 
 
-    <!-- 어디에 기록할 것인가 (Appender) -->
+
+    <!-- 어디에 기록할 것인가 (콘솔Appender) -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender"> <!-- 콘솔에 로그를 기록하는 Appender 설정 -->
         <encoder> <!-- 어떻게 출력할 것인가 Encoder -->
             <pattern>${CONSOLE_LOG_PATTERN}</pattern> <!-- 인코딩할 패턴설정 -->
         </encoder>
     </appender>
 
+
+    <!-- 롤링 파일Appender: INFO 레벨 이상의 로그를 파일에 기록 -->
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender"> <!-- 파일에 로그를 기록하는 Appender 설정 -->
+
+        <!-- 어떻게 출력할 것인가 Encoder -->
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern> <!-- 인코딩할 패턴설정 -->
+        </encoder>
+
+        <!-- 롤링 정책: 로그 파일을 일정 크기 또는 시간 단위로 롤링(분할) -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/pium-info-%d{yyyy-MM-dd}.%i.log</fileNamePattern> <!-- 롤링된 파일 이름 패턴 설정 -->
+            <maxFileSize>50MB</maxFileSize> <!-- 최대 파일 크기 설정 -->
+            <maxHistory>30</maxHistory> <!-- 보관할 최대 파일 수 설정 -->
+            <totalSizeCap>1GB</totalSizeCap> <!-- 전체 로그 파일의 최대 크기 설정 -->
+        </rollingPolicy>
+    </appender>
+
+    <!-- 에러 로그를 기록할 롤링 파일Appender: ERROR 레벨 로그만 기록 -->
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level> <!-- 필터링할 로그 레벨 설정 -->
+            <onMatch>ACCEPT</onMatch> <!-- 조건이 맞을 때 로그 기록 허용 -->
+            <onMismatch>DENY</onMismatch> <!-- 조건이 맞지 않을 때 로그 기록 거부 -->
+        </filter>
+
+        <!-- 어떻게 출력할 것인가 Encoder -->
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern> <!-- 파일에 기록할 패턴 설정 -->
+        </encoder>
+
+        <!-- 롤링 정책: 로그 파일을 일정 크기 또는 시간 단위로 롤링(분할) -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/pium-error-%d{yyyy-MM-dd}.%i.log</fileNamePattern> <!-- 롤링된 파일 이름 패턴 설정 -->
+            <maxFileSize>50MB</maxFileSize> <!-- 최대 파일 크기 설정 -->
+            <maxHistory>30</maxHistory> <!-- 보관할 최대 파일 수 설정 -->
+            <totalSizeCap>3GB</totalSizeCap> <!-- 전체 로그 파일의 최대 크기 설정 -->
+        </rollingPolicy>
+    </appender>
+
+
+
     <!-- 루트로거: 최상위 로거 설정 (INFO 레벨 이상의 로그를 콘솔에 기록)-->
     <root level="INFO">
-        <appender-ref ref="CONSOLE"/> <!-- CONSOLE Appender를 root logger에 연결 -->
+        <appender-ref ref="CONSOLE"/> <!-- 콘솔 Appender를 root logger에 연결 -->
+        <appender-ref ref="FILE-INFO"/> <!-- 파일-INFO Appender를 root logger에 연결 -->
+        <appender-ref ref="FILE-ERROR"/> <!-- 파일-ERROR Appender를 root logger에 연결 -->
     </root>
+
+
 
 </configuration>


### PR DESCRIPTION
## 🛠️ 작업 내용
- 롤링 파일Appender를 추가하여 `INFO 레벨` 로그와 `ERRROR레벨` 로그를 나누어 파일로 저장하도록 하였습니다.
- 프로젝트의 log폴더에 들어가면 error파일은 에러로그를, info 파일은 인포로그를 찾을 수 있습니다.

<br/>

## ⚡️ Issue number & Link
- #21 

<br/>

## 📝 체크 리스트
- [x] 롤링 파일Appender 추가 구현
- [x] 롤링 정책 수립
- [x] INFO 레벨과 ERRROR레벨로 나누어 로그를 저장

<br/>