### PR TITLE
refactor : 탈퇴 안 한 회원만 조회하는 어노테이션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     implementation 'net.logstash.logback:logstash-logback-encoder:7.0.1'
 
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    implementation 'org.hibernate.orm:hibernate-core:6.2.2.Final'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/clean/cleanroom/partner/entity/Partner.java
+++ b/src/main/java/com/clean/cleanroom/partner/entity/Partner.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor
+@Where(clause = "is_deleted = false")  // 삭제되지 않은 데이터만 조회
 public class Partner {
 
     @Id

--- a/src/main/java/com/clean/cleanroom/partner/repository/PartnerRepository.java
+++ b/src/main/java/com/clean/cleanroom/partner/repository/PartnerRepository.java
@@ -2,12 +2,18 @@ package com.clean.cleanroom.partner.repository;
 
 import com.clean.cleanroom.partner.entity.Partner;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PartnerRepository extends JpaRepository<Partner, Long> {
 
     Optional<Partner> findByEmail(String email);
+
+    // 소프트 딜리트된 파트너도 포함한 조회 메서드
+    @Query("SELECT p FROM Partner p WHERE p.email = :email")
+    Optional<Partner> findByEmailIncludingDeleted(@Param("email") String email);
 
     boolean existsByEmail(String email);
 


### PR DESCRIPTION
## 🛠️ 작업 내용
- 파트너 조회 시 탈퇴하지 않은 파트너만 조회하는 어노테이션 추가 
- 

<br/>

## ⚡️ Issue number & Link
- #71 
- 

<br/>

## 📝 체크 리스트
- [x] partner 엔티티에 @where 어노테이션 추가 